### PR TITLE
fix ens interfaces matching

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -221,7 +221,7 @@ disks_list=$(talosctl -e "${node}" -n "${node}" disks ${OPTS} | awk 'NR>1 {sub(/
 disk=$(echo "${disks_list}" | dialog --keep-tite --title talos-bootstrap --menu "Select disk to install" 0 0 0 --file /dev/stdin 3>&1 1>&2 2>&3) || exit 0
 
 # Screen: Select interface
-link_list=$(talosctl -e "${node}" -n "${node}" get link ${OPTS} | awk -F'  +' 'NR>1 && $4 ~ /^(ID|eno|eth|enp|enx)/ {print $4 "|" $(NF-2)}')
+link_list=$(talosctl -e "${node}" -n "${node}" get link ${OPTS} | awk -F'  +' 'NR>1 && $4 ~ /^(ID|eno|eth|enp|enx|ens)/ {print $4 "|" $(NF-2)}')
 address_list=$(talosctl -e "${node}" -n "${node}" get addresses ${OPTS} | awk 'NR>1 {print $NF " " $(NF-1)}') || exit 0
 
 interface_list=$(


### PR DESCRIPTION
ens18 is not shown:

```
root@cozystack:~# talosctl -e 10.1.1.29 -n 10.1.1.29 get link -i
NODE   NAMESPACE   TYPE         ID        VERSION   TYPE       KIND     HW ADDR                                           OPER STATE   LINK STATE
       network     LinkStatus   bond0     1         ether      bond     2a:b6:87:5e:f3:fc                                 down         false
       network     LinkStatus   dummy0    1         ether      dummy    3e:58:73:07:2b:b5                                 down         false
       network     LinkStatus   ens18     3         ether               da:12:57:d6:2b:38                                 up           true
       network     LinkStatus   ip6tnl0   1         tunnel6    ip6tnl   00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00   down         false
       network     LinkStatus   lo        1         loopback            00:00:00:00:00:00                                 unknown      true
       network     LinkStatus   sit0      1         sit        sit      00:00:00:00                                       down         false
       network     LinkStatus   teql0     1         void                                                                  down         false
       network     LinkStatus   tunl0     1         ipip       ipip     00:00:00:00                                       down         false
root@cozystack:~# talosctl -e 10.1.1.29 -n 10.1.1.29 get link -i | awk '-F  +' 'NR>1 && $4 ~ /^(ID|eno|eth|enp|enx)/ {print $4 "|" $(NF-2)}'
```