### PR TITLE
Fix etcd install

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -500,8 +500,19 @@ else
 fi
 
 if [ "${should_bootstrap}" = 1 ]; then
-  talosctl --talosconfig=talosconfig -e "${node}" -n "${node}" bootstrap
+  count=0
+  max_retries=20
+  while ! nmap -Pn ${vip_address} -p 50000 | grep -q 'open' && [ ${count} -lt ${max_retries} ]; do
+    count=$((count+1))
+    sleep 5
+    talosctl --talosconfig=talosconfig -e "${node}" -n "${node}" bootstrap
+  done
+  if [ ${count} -ge ${max_retries} ]; then
+    dialog --keep-tite --title "talos-bootstrap" --msgbox "Port 50000 closed, ETCD is not installed!" 5 26
+    exit 1
+  fi
 fi
+
 
 # Saving cluster configuration
 cat > cluster.conf <<EOT


### PR DESCRIPTION
ETCD was not always installed when selecting install. Added API availability check after ETCD installation request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a retry mechanism for the `talosctl bootstrap` command to enhance reliability during node bootstrapping.
	- Added a check for port 50000 to ensure ETCD is installed before proceeding with bootstrapping.

- **Bug Fixes**
	- Improved error handling by providing a dialog message if ETCD is not installed after maximum retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->