### PR TITLE
version check

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -56,6 +56,20 @@ case "$OP" in
     ;;
 esac
 
+# Version check
+command -V dialog || exit 1
+command -V talosctl || exit 1
+command -V awk || exit 1
+if [ "$node" = "" ]; then
+  command -V nmap || exit 1
+fi
+
+VERSION_REQUIRED=v1.9
+if [ $(echo "${VERSION_REQUIRED}\n$(talosctl version --client | awk '$1 == "Tag:" {print $2}')" | sort -V | tail -n 1) = "${VERSION_REQUIRED}" ]; then
+  echo "talos-bootstrap requires talosctl version ${VERSION_REQUIRED} or higher. Please check 'talosctl version --client'"
+  exit 1
+fi
+
 # Load cluster configuration
 if [ -f cluster.conf ]; then
   for key in BOOTSTRAP_ETCD CLUSTER_NAME KUBERNETES_API_ENDPOINT VIP_ADDRESS; do

--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -132,7 +132,7 @@ else
       manufacturer=$(talosctl -e "${node}" -n "${node}" get cpu ${OPTS} -o jsonpath='{.spec.manufacturer}' | head -n1)
       cpu=$(talosctl -e "${node}" -n "${node}" get cpu ${OPTS} -o jsonpath='{.spec.threadCount}' | awk '{sum+=$1;} END{print sum "-core";}')
       ram=$(talosctl -e "${node}" -n "${node}" get ram -o json ${OPTS} | awk '/"sizeMiB":/ {sub(",", ""); sum+=$2} END{print sum/1024 "GB"}')
-      disks=$(talosctl -e "${node}" -n "${node}" disks ${OPTS} | awk 'NR>1 {sub(/^[^/]*/, ""); print}' | awk -F'  +' '{print $1 ":" $9}' | awk -F/ '$2 == "dev" {print $3}' | awk 'gsub(" ", "", $0)' | awk '$1=$1' RS="," OFS=",")
+      disks=$(talosctl -e "${node}" -n "${node}" disks ${OPTS} | awk 'NR>1 {sub(/^[^/]*/, ""); print}' | awk -F'  +' '{print $1 ":" $9}' | awk -F/ '$2 == "dev" && $3 !~ "^(zd|drbd|loop)" {print $3}' | awk 'gsub(" ", "", $0)' | awk '$1=$1' RS="," OFS=",")
       echo "\"${name}\"" "\"${mac}, ${cpu} ${manufacturer:-CPU}, RAM: ${ram}, Disks: [${disks}]\"" >> "${node_list_file}"
     done
 


### PR DESCRIPTION
- Remove loop, drbd and zfs devices from disk selection
- Add talosctl version check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a version check for the `talos-bootstrap` script to ensure compatibility with the `talosctl` client.
	- Enhanced disk filtering to exclude specific device types from the output. 

- **Bug Fixes**
	- Improved error handling by displaying a message when the `talosctl` version does not meet the minimum requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->