### PR TITLE
[docs] Show the help message when using -h or --help

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -19,7 +19,6 @@ show_help() {
     printf "\t%s\t%s\n" "dashboard" "Open dashboard for a node."
     printf "\nOPTIONS:\n"
     printf "\t%s <%s>\t%s\n" "-n, --node" "address" "Node address"
-    exit 1
 }
 
 node=
@@ -61,6 +60,7 @@ case "$OP" in
     ;;
   *)
     show_help
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
I had the experience of blindly executing --help and -h for talos bootstrap and I was confused this didn't exist 

Resolves #13

The proper way way to use "help" as it was interpreted as a undefined command

Adding explicit help message handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Added support for -h and --help flags to display usage instructions and available actions.
  - Introduced a unified help message listing all supported actions and options.

- **Refactor**
  - Standardized and centralized help output for easier access and improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->