### PR TITLE
Fix listing disks with MODEL=Virtual Disk

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -152,7 +152,7 @@ else
       manufacturer=$(talosctl -e "${node}" -n "${node}" get cpu ${OPTS} -o jsonpath='{.spec.manufacturer}' | head -n1)
       cpu=$(talosctl -e "${node}" -n "${node}" get cpu ${OPTS} -o jsonpath='{.spec.threadCount}' | awk '{sum+=$1;} END{print sum "-core";}')
       ram=$(talosctl -e "${node}" -n "${node}" get ram -o json ${OPTS} | awk '/"sizeMiB":/ {sub(",", ""); sum+=$2} END{print sum/1024 "GB"}')
-      disks=$(talosctl -e "${node}" -n "${node}" get disks ${OPTS} | awk 'sub(/^.*Disk +/, "", $0) {print $0}' | awk '$1 !~ "^(zd|drbd|loop|sr)" {print $1 ":" $3$4}' | awk '$1=$1' RS="," OFS=",")
+      disks=$(talosctl -e "${node}" -n "${node}" get disks ${OPTS} | awk 'sub(/^.*runtime +Disk +/, "", $0) {print $0}' | awk '$1 !~ "^(zd|drbd|loop|sr)" {print $1 ":" $3$4}' | awk '$1=$1' RS="," OFS=",")
       echo "\"${name}\"" "\"${mac}, ${cpu} ${manufacturer:-CPU}, RAM: ${ram}, Disks: [${disks}]\"" >> "${node_list_file}"
     done
 


### PR DESCRIPTION
Example output:

```bash
# talosctl get disks -i
NODE   NAMESPACE   TYPE   ID       VERSION   SIZE     READ ONLY   TRANSPORT      ROTATIONAL   WWID                                   MODEL             SERIAL
       runtime     Disk   loop0    1         164 kB   true
       runtime     Disk   loop1    1         7.5 MB   true
       runtime     Disk   loop10   1         74 MB    true
       runtime     Disk   loop2    1         573 kB   true
       runtime     Disk   loop3    1         11 MB    true
       runtime     Disk   loop4    1         10 MB    true
       runtime     Disk   loop5    1         70 kB    true
       runtime     Disk   loop6    1         4.1 kB   true
       runtime     Disk   loop7    1         2.5 MB   true
       runtime     Disk   loop8    1         4.1 kB   true
       runtime     Disk   loop9    1         94 kB    true
       runtime     Disk   sda      1         54 GB    false       storvsc_host   true         naa.600224808bd9ef0f67e37b953b724fc7   Virtual Disk
       runtime     Disk   sr0      1         156 MB   false       storvsc_host                                                       Virtual DVD-ROM
```

Awk uses greedy search for the word Disk so the whole line get removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk information parsing to more accurately extract relevant disk details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->